### PR TITLE
Fix bug in `repayDebt(...)` in `DelayedRepayCollateral`

### DIFF
--- a/examples/DelayedRepayCollateral.sol
+++ b/examples/DelayedRepayCollateral.sol
@@ -107,7 +107,7 @@ contract DelayedRepayCollateral is ERC20, Ownable, ICollateral {
             revert();
         }
 
-        IERC20(asset).safeTransferFrom(msg.sender, recipient, amount);
+        IERC20(asset).safeTransfer(recipient, amount);
 
         totalDebt -= amount;
         issuerDebt[issuer] -= amount;


### PR DESCRIPTION
This would make the transfer form consistent with the other examples plus with `DefaultCollateral`.